### PR TITLE
upgrade to latest Sonobe version (speedup)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 3
 
 [[package]]
 name = "acir"
-version = "0.48.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
+version = "1.0.0-beta.0"
+source = "git+https://github.com/winderica/noir?branch=arkworks-next#5cf5e5c37e4388e6df1b35862b830397608dbe06"
 dependencies = [
  "acir_field",
  "base64 0.21.7",
@@ -14,16 +14,18 @@ dependencies = [
  "flate2",
  "serde",
  "serde-big-array",
+ "strum",
+ "strum_macros",
  "thiserror",
 ]
 
 [[package]]
 name = "acir_field"
-version = "0.48.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
+version = "1.0.0-beta.0"
+source = "git+https://github.com/winderica/noir?branch=arkworks-next#5cf5e5c37e4388e6df1b35862b830397608dbe06"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ff 0.4.1",
+ "ark-bn254 0.5.0",
+ "ark-ff 0.5.0",
  "cfg-if",
  "hex",
  "num-bigint",
@@ -32,14 +34,14 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "0.48.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
+version = "1.0.0-beta.0"
+source = "git+https://github.com/winderica/noir?branch=arkworks-next#5cf5e5c37e4388e6df1b35862b830397608dbe06"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
  "brillig_vm",
+ "fxhash",
  "indexmap 1.9.3",
- "num-bigint",
  "serde",
  "thiserror",
  "tracing",
@@ -47,8 +49,8 @@ dependencies = [
 
 [[package]]
 name = "acvm_blackbox_solver"
-version = "0.48.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
+version = "1.0.0-beta.0"
+source = "git+https://github.com/winderica/noir?branch=arkworks-next#5cf5e5c37e4388e6df1b35862b830397608dbe06"
 dependencies = [
  "acir",
  "blake2",
@@ -59,7 +61,6 @@ dependencies = [
  "num-bigint",
  "p256",
  "sha2",
- "sha3",
  "thiserror",
 ]
 
@@ -115,6 +116,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -181,21 +188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arithmetic"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hyperplonk#dc194f83ef5cae523b869f7256f314bdbeb2a42c"
-dependencies = [
- "ark-bls12-381 0.4.0",
- "ark-ff 0.4.1",
- "ark-poly 0.4.1",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
- "displaydoc",
- "rand_chacha 0.3.1",
- "rayon",
-]
-
-[[package]]
 name = "ark-bls12-381"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,18 +196,6 @@ dependencies = [
  "ark-ec 0.3.0",
  "ark-ff 0.3.0",
  "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-bls12-381"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
-dependencies = [
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -231,29 +211,30 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
-version = "0.4.0"
-source = "git+https://github.com/arnaucube/ark-curves-cherry-picked?branch=cherry-pick#5d56cc26308565e4a0195c2e349115d2ccf2713f"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
  "ark-r1cs-std",
- "ark-std 0.4.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
 name = "ark-circom"
 version = "0.1.0"
-source = "git+https://github.com/arnaucube/circom-compat#74afb0a0ccd51c060285634c4c59c67bc7ec8822"
+source = "git+https://github.com/winderica/circom-compat?branch=arkworks-next#9f8d7cedd5db06e46118259a5672a3a32fbf7bb7"
 dependencies = [
- "ark-bn254 0.4.0",
+ "ark-bn254 0.5.0",
  "ark-crypto-primitives",
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
  "ark-groth16",
- "ark-poly 0.4.1",
- "ark-relations 0.4.0",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
+ "ark-poly 0.5.0",
+ "ark-relations 0.5.1",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "byteorder",
  "cfg-if",
  "color-eyre",
@@ -270,23 +251,39 @@ dependencies = [
 
 [[package]]
 name = "ark-crypto-primitives"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3a13b34da09176a8baba701233fdffbaa7c1b1192ce031a3da4e55ce1f1a56"
+checksum = "1e0c292754729c8a190e50414fd1a37093c786c709899f29c9f7daccecfa855e"
 dependencies = [
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
+ "ahash 0.8.11",
+ "ark-crypto-primitives-macros",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
  "ark-r1cs-std",
- "ark-relations 0.4.0",
- "ark-serialize 0.4.1",
+ "ark-relations 0.5.1",
+ "ark-serialize 0.5.0",
  "ark-snark",
- "ark-std 0.4.0",
+ "ark-std 0.5.0",
  "blake2",
  "derivative",
  "digest 0.10.7",
+ "fnv",
+ "hashbrown 0.14.5",
+ "merlin",
  "rayon",
  "sha2",
  "tracing",
+]
+
+[[package]]
+name = "ark-crypto-primitives-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e89fe77d1f0f4fe5b96dfc940923d88d17b6a773808124f21e764dfb063c6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -306,17 +303,21 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c60370a92f8e1a5f053cad73a862e1b99bc642333cd676fa11c0c39f80f4ac2"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
- "ark-ff 0.4.1",
- "ark-poly 0.4.1",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
+ "ahash 0.8.11",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
  "num-traits",
  "rayon",
  "zeroize",
@@ -343,22 +344,22 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2d42532524bee1da5a4f6f733eb4907301baa480829557adcff5dfaeee1d9a"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
- "derivative",
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
  "digest 0.10.7",
- "itertools 0.10.5",
+ "educe",
+ "itertools 0.13.0",
  "num-bigint",
  "num-traits",
  "paste",
  "rayon",
- "rustc_version 0.4.1",
  "zeroize",
 ]
 
@@ -374,12 +375,12 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -396,56 +397,44 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
  "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "ark-groth16"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ceafa83848c3e390f1cbf124bc3193b3e639b3f02009e0e290809a501b95fc"
+checksum = "88f1d0f3a534bb54188b8dcc104307db6c56cdae574ddc3212aec0625740fc7e"
 dependencies = [
  "ark-crypto-primitives",
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
- "ark-poly 0.4.1",
- "ark-relations 0.4.0",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-relations 0.5.1",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "rayon",
 ]
 
 [[package]]
 name = "ark-grumpkin"
-version = "0.4.0"
-source = "git+https://github.com/arnaucube/ark-curves-cherry-picked?branch=cherry-pick#5d56cc26308565e4a0195c2e349115d2ccf2713f"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef677b59f5aff4123207c4dceb1c0ec8fdde2d4af7886f48be42ad864bfa0352"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
  "ark-r1cs-std",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-noname"
-version = "0.1.0"
-source = "git+https://github.com/dmpierre/ark-noname?branch=feat/sonobe-integration#caf7585aac5cc92fc319d649b0b564a8d9899fcf"
-dependencies = [
- "ark-bn254 0.4.0",
- "ark-ff 0.4.1",
- "ark-r1cs-std",
- "ark-relations 0.4.0",
- "noname",
- "num-bigint",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -464,46 +453,55 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6ec811462cabe265cfe1b102fcfe3df79d7d2929c2425673648ee9abfd0272"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
- "ark-ff 0.4.1",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
+ "ahash 0.8.11",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
  "rayon",
 ]
 
 [[package]]
 name = "ark-poly-commit"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a741492629ffcd228337676dc223a28551aa6792eedb8a2a22c767f00df6c89"
+checksum = "7d68a105d915bcde6c0687363591c97e72d2d3758f3532d48fd0bf21a3261ce7"
 dependencies = [
+ "ahash 0.8.11",
  "ark-crypto-primitives",
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
- "ark-poly 0.4.1",
- "ark-relations 0.4.0",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-relations 0.5.1",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "blake2",
  "derivative",
  "digest 0.10.7",
+ "fnv",
+ "merlin",
+ "num-traits",
+ "rand 0.8.5",
  "rayon",
 ]
 
 [[package]]
 name = "ark-r1cs-std"
-version = "0.4.0"
-source = "git+https://github.com/winderica/r1cs-std?branch=cherry-pick#8e71ee527ebbbb9bc966167be7373c7a1b74fc9c"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
 dependencies = [
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
- "ark-relations 0.4.0",
- "ark-std 0.4.0",
- "derivative",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-relations 0.5.1",
+ "ark-std 0.5.0",
+ "educe",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -523,12 +521,12 @@ dependencies = [
 
 [[package]]
 name = "ark-relations"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
 dependencies = [
- "ark-ff 0.4.1",
- "ark-std 0.4.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
  "tracing",
  "tracing-subscriber 0.2.25",
 ]
@@ -546,14 +544,16 @@ dependencies = [
 
 [[package]]
 name = "ark-serialize"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e735959bc173ea4baf13327b19c22d452b8e9e8e8f7b7fc34e6bf0e316c33e"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive 0.4.2",
- "ark-std 0.4.0",
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
  "digest 0.10.7",
  "num-bigint",
+ "rayon",
 ]
 
 [[package]]
@@ -569,25 +569,25 @@ dependencies = [
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "ark-snark"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
+checksum = "d368e2848c2d4c129ce7679a7d0d2d612b6a274d3ea6a13bad4445d61b381b88"
 dependencies = [
- "ark-ff 0.4.1",
- "ark-relations 0.4.0",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
+ "ark-ff 0.5.0",
+ "ark-relations 0.5.1",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -603,34 +603,13 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
  "rayon",
-]
-
-[[package]]
-name = "arkworks_backend"
-version = "0.1.0"
-source = "git+https://github.com/dmpierre/arkworks_backend?branch=feat/sonobe-integration#be5d2f075f426fad036bfcd06bf74d87f78f8323"
-dependencies = [
- "acvm",
- "ark-bn254 0.4.0",
- "ark-ff 0.4.1",
- "ark-r1cs-std",
- "ark-relations 0.4.0",
- "cfg-if",
- "fm",
- "noirc_abi",
- "noirc_artifacts",
- "noirc_driver",
- "noirc_errors",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -644,15 +623,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
 
 [[package]]
 name = "atty"
@@ -690,20 +660,6 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
-name = "aztec_macros"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "acvm",
- "convert_case",
- "iter-extended",
- "noirc_errors",
- "noirc_frontend",
- "regex",
- "tiny-keccak",
-]
 
 [[package]]
 name = "backtrace"
@@ -745,12 +701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,21 +726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,15 +736,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "bitvec"
@@ -855,25 +781,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "bn254_blackbox_solver"
-version = "0.48.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "acir",
- "acvm_blackbox_solver",
- "ark-bn254 0.4.0",
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
- "hex",
- "lazy_static",
- "noir_grumpkin",
- "num-bigint",
-]
-
-[[package]]
 name = "brillig"
-version = "0.48.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
+version = "1.0.0-beta.0"
+source = "git+https://github.com/winderica/noir?branch=arkworks-next#5cf5e5c37e4388e6df1b35862b830397608dbe06"
 dependencies = [
  "acir_field",
  "serde",
@@ -881,25 +791,14 @@ dependencies = [
 
 [[package]]
 name = "brillig_vm"
-version = "0.48.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
+version = "1.0.0-beta.0"
+source = "git+https://github.com/winderica/noir?branch=arkworks-next#5cf5e5c37e4388e6df1b35862b830397608dbe06"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
  "num-bigint",
  "num-traits",
  "thiserror",
-]
-
-[[package]]
-name = "build-data"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed3884e2cab7c973c8fd2d150314b6a932df7fdc830edcaf1e8e7c4ae9db3c0"
-dependencies = [
- "chrono",
- "safe-lock",
- "safe-regex",
 ]
 
 [[package]]
@@ -986,19 +885,9 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets",
-]
-
-[[package]]
-name = "chumsky"
-version = "0.8.0"
-source = "git+https://github.com/jfecher/chumsky?rev=ad9d312#ad9d312d9ffbc66c14514fa2b5752f4127b44f1e"
-dependencies = [
- "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1063,27 +952,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
-name = "codespan"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
-dependencies = [
- "codespan-reporting",
- "serde",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "serde",
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "color-eyre"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,15 +1008,6 @@ source = "git+https://github.com/iden3/circom.git?tag=v2.1.8#f0deda416abe91e5dd9
 dependencies = [
  "circom_algebra",
  "json",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1522,16 +1381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,32 +1392,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "disjoint-set"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d102f1a462fdcdddce88d6d46c06c074a2d2749b262230333726b06c52bb7585"
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
 
 [[package]]
 name = "ecdsa"
@@ -1815,6 +1642,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "experimental-frontends"
+version = "0.1.0"
+source = "git+https://github.com/privacy-scaling-explorations/sonobe?rev=c6f1a246e0705582a75de6becf4ad21f325fa5a1#c6f1a246e0705582a75de6becf4ad21f325fa5a1"
+dependencies = [
+ "acvm",
+ "ark-circom",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-relations 0.5.1",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "folding-schemes",
+ "getrandom 0.2.15",
+ "noname",
+ "num-bigint",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,12 +1716,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,16 +1723,6 @@ checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
-]
-
-[[package]]
-name = "fm"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "codespan-reporting",
- "iter-extended",
- "serde",
 ]
 
 [[package]]
@@ -1903,36 +1734,27 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "folding-schemes"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/sonobe?rev=f1d82418ba047cf90805f2d0505370246df24d68#f1d82418ba047cf90805f2d0505370246df24d68"
+source = "git+https://github.com/privacy-scaling-explorations/sonobe?rev=c6f1a246e0705582a75de6becf4ad21f325fa5a1#c6f1a246e0705582a75de6becf4ad21f325fa5a1"
 dependencies = [
- "acvm",
- "ark-bn254 0.4.0",
- "ark-circom",
+ "ark-bn254 0.5.0",
  "ark-crypto-primitives",
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
  "ark-groth16",
  "ark-grumpkin",
- "ark-noname",
- "ark-poly 0.4.1",
+ "ark-poly 0.5.0",
  "ark-poly-commit",
  "ark-r1cs-std",
- "ark-relations 0.4.0",
- "ark-serialize 0.4.1",
+ "ark-relations 0.5.1",
+ "ark-serialize 0.5.0",
  "ark-snark",
- "ark-std 0.4.0",
- "arkworks_backend",
- "color-eyre",
+ "ark-std 0.5.0",
  "getrandom 0.2.15",
  "log",
- "noname",
  "num-bigint",
  "num-integer",
  "rayon",
- "serde",
- "serde_json",
  "sha3",
- "subroutines",
  "thiserror",
 ]
 
@@ -2162,18 +1984,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "allocator-api2",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -2259,21 +2084,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "serde",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,7 +2146,6 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
- "serde",
 ]
 
 [[package]]
@@ -2368,24 +2177,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "iter-extended"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -2419,18 +2214,6 @@ name = "json"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
-name = "jsonrpc"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efde8d2422fb79ed56db1d3aea8fa5b583351d15a26770cdee2f88813dd702"
-dependencies = [
- "base64 0.13.1",
- "minreq",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "k256"
@@ -2503,37 +2286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax 0.8.4",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata 0.4.7",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,16 +2343,6 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg 1.3.0",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -2768,185 +2510,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "minreq"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763d142cdff44aaadd9268bebddb156ef6c65a0e13486bb81673cf2d8739f9b0"
-dependencies = [
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "noir_grumpkin"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7d49a4b14b13c0dc730b05780b385828ab88f4148daaad7db080ecdce07350"
-dependencies = [
- "ark-bn254 0.4.0",
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "noirc_abi"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "acvm",
- "iter-extended",
- "noirc_printable_type",
- "num-bigint",
- "num-traits",
- "serde",
- "serde_json",
- "thiserror",
- "toml 0.7.8",
-]
-
-[[package]]
-name = "noirc_arena"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-
-[[package]]
-name = "noirc_artifacts"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "acvm",
- "codespan-reporting",
- "fm",
- "noirc_abi",
- "noirc_driver",
- "noirc_errors",
- "noirc_printable_type",
- "serde",
-]
-
-[[package]]
-name = "noirc_driver"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "acvm",
- "aztec_macros",
- "build-data",
- "clap 4.5.18",
- "fm",
- "fxhash",
- "iter-extended",
- "noirc_abi",
- "noirc_errors",
- "noirc_evaluator",
- "noirc_frontend",
- "rust-embed",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "noirc_errors"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "acvm",
- "base64 0.21.7",
- "chumsky",
- "codespan",
- "codespan-reporting",
- "flate2",
- "fm",
- "noirc_printable_type",
- "serde",
- "serde_json",
- "serde_with 3.9.0",
- "tracing",
-]
-
-[[package]]
-name = "noirc_evaluator"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "acvm",
- "bn254_blackbox_solver",
- "chrono",
- "fxhash",
- "im",
- "iter-extended",
- "noirc_errors",
- "noirc_frontend",
- "num-bigint",
- "serde",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "noirc_frontend"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "acvm",
- "cfg-if",
- "chumsky",
- "fm",
- "im",
- "iter-extended",
- "lalrpop",
- "lalrpop-util",
- "noirc_arena",
- "noirc_errors",
- "noirc_printable_type",
- "num-bigint",
- "num-traits",
- "petgraph",
- "rangemap",
- "regex",
- "rustc-hash",
- "serde",
- "serde_json",
- "small-ord-set",
- "smol_str",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "noirc_printable_type"
-version = "0.32.0"
-source = "git+https://github.com/noir-lang/noir?rev=2b4853e#2b4853e71859f225acc123160e87c522212b16b5"
-dependencies = [
- "acvm",
- "iter-extended",
- "jsonrpc",
- "regex",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "noname"
 version = "0.7.0"
 source = "git+https://github.com/dmpierre/noname#c34f173123707b34d365070783c2e701fec1eb44"
 dependencies = [
- "ark-bls12-381 0.3.0",
+ "ark-bls12-381",
  "ark-bn254 0.3.0",
  "ark-ec 0.3.0",
  "ark-ff 0.3.0",
@@ -2972,7 +2546,7 @@ dependencies = [
  "serde_json",
  "serde_with 2.3.3",
  "thiserror",
- "toml 0.8.19",
+ "toml",
 ]
 
 [[package]]
@@ -3095,6 +2669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.3.0",
+ "libm",
 ]
 
 [[package]]
@@ -3249,29 +2824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,31 +2839,6 @@ dependencies = [
  "thiserror",
  "ucd-trie",
 ]
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.5.0",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -3349,11 +2876,12 @@ dependencies = [
 name = "playground"
 version = "0.1.0"
 dependencies = [
- "ark-bn254 0.4.0",
+ "ark-bn254 0.5.0",
  "ark-crypto-primitives",
  "ark-groth16",
  "ark-grumpkin",
- "ark-serialize 0.4.1",
+ "ark-serialize 0.5.0",
+ "experimental-frontends",
  "folding-schemes",
  "itertools 0.13.0",
  "num-traits",
@@ -3429,12 +2957,6 @@ checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "primitive-types"
@@ -3609,21 +3131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rangemap"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
-
-[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3641,15 +3148,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
-dependencies = [
- "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -3869,40 +3367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "6.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "6.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.77",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "7.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
-dependencies = [
- "sha2",
- "walkdir",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3962,59 +3426,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "safe-lock"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077d73db7973cccf63eb4aff1e5a34dc2459baa867512088269ea5f2f4253c90"
-
-[[package]]
-name = "safe-proc-macro2"
-version = "1.0.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd85be67db87168aa3c13fd0da99f48f2ab005dccad5af5626138dc1df20eb6"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "safe-quote"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e530f7831f3feafcd5f1aae406ac205dd998436b4007c8e80f03eca78a88f7"
-dependencies = [
- "safe-proc-macro2",
-]
-
-[[package]]
-name = "safe-regex"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ab4bc484ef480a9ce79b381efd7b6767700f514d47bc599036e9d6f7f3c49d"
-dependencies = [
- "safe-regex-macro",
-]
-
-[[package]]
-name = "safe-regex-compiler"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71f8c78bffb07962595e1bfa5ed11d24dd855eedc50b6a735f5ef648ce621b"
-dependencies = [
- "safe-proc-macro2",
- "safe-quote",
-]
-
-[[package]]
-name = "safe-regex-macro"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0909ab4b77511df24201cd66541d6a028887c77ecc065f277c68a12a663274ef"
-dependencies = [
- "safe-proc-macro2",
- "safe-regex-compiler",
-]
 
 [[package]]
 name = "same-file"
@@ -4209,24 +3620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.5.0",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros 3.9.0",
- "time",
-]
-
-[[package]]
 name = "serde_with_macros"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,18 +3636,6 @@ name = "serde_with_macros"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling 0.20.10",
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -4325,37 +3706,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg 1.3.0",
-]
-
-[[package]]
-name = "small-ord-set"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7035a2b2268a5be8c1395738565b06beda836097e12021cdefc06b127a0e7e"
-dependencies = [
- "smallvec",
 ]
 
 [[package]]
@@ -4369,15 +3725,6 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
-name = "smol_str"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "spin"
@@ -4418,19 +3765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "string_cache"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
-dependencies = [
- "new_debug_unreachable",
- "once_cell",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4462,27 +3796,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "subroutines"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hyperplonk#dc194f83ef5cae523b869f7256f314bdbeb2a42c"
-dependencies = [
- "arithmetic",
- "ark-bls12-381 0.4.0",
- "ark-ec 0.4.1",
- "ark-ff 0.4.1",
- "ark-poly 0.4.1",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
- "derivative",
- "displaydoc",
- "itertools 0.13.0",
- "rand_chacha 0.3.1",
- "rayon",
- "transcript",
- "util",
 ]
 
 [[package]]
@@ -4564,26 +3877,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -4713,18 +4006,6 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
@@ -4751,8 +4032,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.5.0",
- "serde",
- "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -4865,18 +4144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "transcript"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hyperplonk#dc194f83ef5cae523b869f7256f314bdbeb2a42c"
-dependencies = [
- "ark-ff 0.4.1",
- "ark-serialize 0.4.1",
- "ark-std 0.4.0",
- "displaydoc",
- "merlin",
-]
-
-[[package]]
 name = "turshi"
 version = "0.1.0"
 source = "git+https://github.com/o1-labs/proof-systems?rev=a5d8883ddf649c22f38aaac122d368ecb9fa2230#a5d8883ddf649c22f38aaac122d368ecb9fa2230"
@@ -4923,12 +4190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4945,14 +4206,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "util"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hyperplonk#dc194f83ef5cae523b869f7256f314bdbeb2a42c"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,20 +5,16 @@ edition = "2021"
 authors = ["Piotr Mikołajczyk <piomiko41@gmail.com>"]
 
 [dependencies]
-ark-bn254 = { version = "^0.4.0", features = ["r1cs"] }
-ark-crypto-primitives = { version = "0.4.0" }
-ark-grumpkin = { version = "0.4.0", features = ["r1cs"] }
-ark-groth16 = { version = "0.4.0", features = ["parallel"] }
-ark-serialize = { version = "0.4.0" }
+ark-bn254 = { version = "^0.5.0", features = ["r1cs"] }
+ark-crypto-primitives = { version = "0.5.0" }
+ark-grumpkin = { version = "0.5.0", features = ["r1cs"] }
+ark-groth16 = { version = "0.5.0", features = ["parallel"] }
+ark-serialize = { version = "0.5.0" }
 itertools = { version = "0.13.0" }
 num-traits = { version = "0.2.15" }
 rand = { version = "0.8.5" }
 tracing = { version = "0.1.26" }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "json", "env-filter"] }
 
-sonobe = { git = "https://github.com/privacy-scaling-explorations/sonobe", rev = "f1d82418ba047cf90805f2d0505370246df24d68", package = "folding-schemes" }
-
-[patch.crates-io]
-ark-r1cs-std = { git = "https://github.com/winderica/r1cs-std", branch = "cherry-pick" }
-ark-bn254 = { git = "https://github.com/arnaucube/ark-curves-cherry-picked", branch = "cherry-pick" }
-ark-grumpkin = { git = "https://github.com/arnaucube/ark-curves-cherry-picked", branch = "cherry-pick" }
+sonobe = { git = "https://github.com/privacy-scaling-explorations/sonobe", rev = "c6f1a246e0705582a75de6becf4ad21f325fa5a1", package = "folding-schemes" }
+experimental-frontends = { git = "https://github.com/privacy-scaling-explorations/sonobe", rev = "c6f1a246e0705582a75de6becf4ad21f325fa5a1", package = "experimental-frontends" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79"
+channel = "1.82.0"
 components = [ "rustfmt", "clippy", "rust-src" ]
 targets = [ "x86_64-unknown-linux-gnu" ]

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,12 +1,13 @@
 use std::env::current_dir;
 
 use ark_bn254::Fr;
-use sonobe::frontend::{circom::CircomFCircuit, FCircuit};
+use experimental_frontends::circom::CircomFCircuit;
+use sonobe::frontend::FCircuit;
 
 const IVC_STEP_WIDTH: usize = 2;
-const STEP_INPUT_WIDTH: usize = 256;
+pub(crate) const STEP_INPUT_WIDTH: usize = 256;
 
-pub fn create_circuit() -> CircomFCircuit<Fr> {
+pub fn create_circuit() -> CircomFCircuit<Fr, STEP_INPUT_WIDTH> {
     let root = current_dir().expect("Failed to get current directory");
     let circuit_file = root.join("circuit/grayscale_step.r1cs");
     let witness_generator_file = root.join("circuit/grayscale_step_js/grayscale_step.wasm");
@@ -15,7 +16,6 @@ pub fn create_circuit() -> CircomFCircuit<Fr> {
         circuit_file.into(),
         witness_generator_file.into(),
         IVC_STEP_WIDTH,
-        STEP_INPUT_WIDTH,
     );
-    CircomFCircuit::<Fr>::new(f_circuit_params).expect("Failed to create circuit")
+    CircomFCircuit::<Fr, STEP_INPUT_WIDTH>::new(f_circuit_params).expect("Failed to create circuit")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,14 +37,7 @@ fn scenario<FS: FoldingSchemeExt>(
 
     // ============== FOLDING VERIFICATION =========================================================
 
-    info_span!("Folding verification").in_scope(|| {
-        verify_folding(
-            &folding,
-            folding_vp,
-            config.start_ivc_state,
-            config.num_inputs,
-        )
-    });
+    info_span!("Folding verification").in_scope(|| verify_folding(&folding, folding_vp));
 }
 
 fn main() {

--- a/src/scenario_config.rs
+++ b/src/scenario_config.rs
@@ -1,15 +1,18 @@
 use ark_bn254::Fr;
+use experimental_frontends::circom::CircomFCircuit;
 use num_traits::Zero;
-use sonobe::frontend::circom::CircomFCircuit;
 use tracing::info_span;
 
-use crate::{circuit::create_circuit, input::prepare_input};
+use crate::{
+    circuit::{create_circuit, STEP_INPUT_WIDTH},
+    input::prepare_input,
+};
 
 #[derive(Clone)]
 pub struct ScenarioConfig {
     pub num_inputs: usize,
     pub start_ivc_state: Vec<Fr>,
-    pub circuit: CircomFCircuit<Fr>,
+    pub circuit: CircomFCircuit<Fr, STEP_INPUT_WIDTH>,
     input: Vec<Vec<Fr>>,
 }
 


### PR DESCRIPTION
This PR upgrades to the latest Sonobe version, which includes some speed ups, specially in HyperNova.

In an AWS `c5a.4xlarge` (16vCPU, 32GB RAM):
- the following image is the run **before** this PR:
![results-previous-to-PR](https://github.com/user-attachments/assets/489457a6-7982-4765-8b8c-15f33d212441)

- the following image is the run **with this PR** (using latest Sonobe version):
![results-with-PR](https://github.com/user-attachments/assets/2fadb9a9-5df4-4158-8fee-c30baeb6691f)

the improvement matches the >65% speedup that we observed in Sonobe's repo benchmarks.

This PR does not update the picture from the README ([hn-grid.png](https://github.com/aleph-zero-foundation/sonobe-playground/blob/main/hn-grid.png)), since it was generated from the run on a different server capacity.